### PR TITLE
shellcheck

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,20 @@
+on:
+  push:
+    branches:
+      - master
+
+name: "Trigger: Push action"
+permissions: {}
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        env:
+          SHELLCHECK_OPTS: -s bash
+        with:
+          severity: error

--- a/Guts/Guts.sh
+++ b/Guts/Guts.sh
@@ -21,6 +21,7 @@ if [ "$#" -lt 2 ]; then
   while [[ "$respuesta" == "n" || "$respuesta" == "a" ]] ;do
     echo $pag
     wget  "https://jkanime.bz/buscar/$1/$pag/" -P /tmp > /dev/null 2>&1
+    # Falta investigar más; Ver https://www.shellcheck.net/wiki/SC2207
     urls=($(grep -A 1 '<div class="anime__item">' /tmp/index.html | awk -F 'href="' '/<a/{print $2}' | awk -F '"' '{print $1}' | xargs -n 1 basename))
     contador=0
     for url in "${urls[@]}";do
@@ -29,7 +30,7 @@ if [ "$#" -lt 2 ]; then
     done
     rm -rf /tmp/index.html
     
-    read -p "Presiona 'n' para seguir iterando, 'a' para retroceder si no pulsa el numero que quieres ver " respuesta
+    read -rp "Presiona 'n' para seguir iterando, 'a' para retroceder si no pulsa el numero que quieres ver " respuesta
     if [[ "$respuesta" =~ ^[0-9]+$ ]] && [ "$respuesta" -ge 0 ] && [ "$respuesta" -lt "${#urls[@]}" ]; then
     # Verificar si la respuesta es un número válido y dentro del rango del array
     url_seleccionada="${urls[$respuesta]}"
@@ -54,7 +55,7 @@ if [ "$#" -lt 2 ]; then
     rm -rf /tmp/jkanime.bz > /dev/null
 
     mpv "$url" > /dev/null
-    read -p "Quiere ver el siguiente capitulo pulse 's' " respuesta
+    read -rp "Quiere ver el siguiente capitulo pulse 's' " respuesta
   done
 
 fi
@@ -73,7 +74,7 @@ if [ "$#" -eq 2 ];then
 
     mpv "$url" > /dev/null
     ((capitulo++))
-    read -p "Quiere ver el siguiente capitulo pulse 's' " respuesta
+    read -rp "Quiere ver el siguiente capitulo pulse 's' " respuesta
 
   done
 fi


### PR DESCRIPTION
shellcheck -s bash Guts.sh me recomienda varias cosas:


In Guts.sh line 24:
    urls=($(grep -A 1 '<div class="anime__item">' /tmp/index.html | awk -F 'href="' '/<a/{print $2}' | awk -F '"' '{print $1}' | xargs -n 1 basename))
          ^-- SC2207 (warning): Prefer mapfile or read -a to split command output (or quote to avoid splitting).


In Guts.sh line 32:
    read -p "Presiona 'n' para seguir iterando, 'a' para retroceder si no pulsa el numero que quieres ver " respuesta
    ^--^ SC2162 (info): read without -r will mangle backslashes.


In Guts.sh line 57:
    read -p "Quiere ver el siguiente capitulo pulse 's' " respuesta
    ^--^ SC2162 (info): read without -r will mangle backslashes.


In Guts.sh line 76:
    read -p "Quiere ver el siguiente capitulo pulse 's' " respuesta
    ^--^ SC2162 (info): read without -r will mangle backslashes.

For more information:
  https://www.shellcheck.net/wiki/SC2207 -- Prefer mapfile or read -a to spli...
  https://www.shellcheck.net/wiki/SC2162 -- read without -r will mangle backs...

Los del -r los he añadido pq es fácil y creo que cumple con la funcionalidad pero vamos que el primero creo que no es lo que quieres y ya lo tocaré cuando me haya leído todo el script en vez de ojearlo.

Además he añadido un pequeño yaml para que github te testee el shellcheck el solito, que la verdad que está muy bien