### PR TITLE
Se añade comando para que tenga permisos de ejecución al usarlo en la terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ para instalarte el script en tu bash, descargate el archivo Guts y ejecuta el si
 
 ```
 sudo cp Guts /usr/bin
-sudo chmod 755 /usr/bin/Guts #para que se pueda ejecutar
+sudo chmod 755 /usr/bin/Guts
 ```
 
 Asi podras usar Guts desde la terminal en cualquier momento.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ para instalarte el script en tu bash, descargate el archivo Guts y ejecuta el si
 
 ```
 sudo cp Guts /usr/bin
+sudo chmod 755 /usr/bin/Guts #para que se pueda ejecutar
 ```
 
 Asi podras usar Guts desde la terminal en cualquier momento.

--- a/README.md
+++ b/README.md
@@ -7,10 +7,15 @@ de [Houman](https://houmanr.xyz/) , tambien se inspira en proyectos angloparlant
 [ani-cli](https://github.com/pystardust/ani-cli)
 
 # Instalación
-para instalarte el script en tu bash, descargate el archivo Guts y ejecuta el siguiente comando:
+para instalarte el script en tu bash, descargate el archivo Guts y ejecuta los siguientes comandos:
 
 ```
 sudo cp Guts /usr/bin
+```
+
+y:
+
+```
 sudo chmod 755 /usr/bin/Guts
 ```
 


### PR DESCRIPTION
Al intentar instalarlo en arch linux como decía en README.md, no me dejaba ejecutarlo, entonces vi que no tenía los permisos adecuados en /usr/bin/, y, al colocarlos, funcionaba todo correctamente. No se si sea el único con el problema, pero para evitar problemas creo que estaría bien colocarlo por si acaso.

![screenshot-20240605181337](https://github.com/danifreflow/Guts/assets/139036190/048e5fdd-fc9a-4102-920f-3be4bad71fbd)
(falta el permiso "x" de ejecución)